### PR TITLE
Fix brand id handling for Mercedes models

### DIFF
--- a/src/components/Categories.tsx
+++ b/src/components/Categories.tsx
@@ -39,19 +39,21 @@ const Categories = () => {
   // Get brands that actually have cars in the database with their count
   const getBrandsWithCarCount = () => {
     const brandCounts = new Map<string, number>();
-    
+
+    const normalizeBrand = (str: string) => str.toLowerCase().replace(/[^a-z]/g, '');
+
     // Count cars for each brand
     massiveCarsDatabase.forEach(car => {
-      const brandId = car.brand.toLowerCase().replace(/[^a-z]/g, '');
+      const brandId = normalizeBrand(car.brand);
       brandCounts.set(brandId, (brandCounts.get(brandId) || 0) + 1);
     });
-    
+
     // Filter brands that have cars and add car count
     return expandedBrands
-      .filter(brand => brandCounts.has(brand.id))
+      .filter(brand => brandCounts.has(normalizeBrand(brand.id)))
       .map(brand => ({
         ...brand,
-        carCount: brandCounts.get(brand.id) || 0
+        carCount: brandCounts.get(normalizeBrand(brand.id)) || 0
       }))
       .sort((a, b) => b.carCount - a.carCount); // Sort by car count (most to least)
   };

--- a/src/pages/BrandPage.tsx
+++ b/src/pages/BrandPage.tsx
@@ -21,7 +21,10 @@ const BrandPage = () => {
   const currentBrand = expandedBrands.find(b => b.id === brand);
   // Combine cars from both databases
   const allCars = [...massiveCarsDatabase, ...additionalCarModels];
-  const brandCars = allCars.filter(car => car.brand.toLowerCase().replace(/[^a-z]/g, '') === brand);
+
+  const normalizeBrand = (str: string) => str.toLowerCase().replace(/[^a-z]/g, '');
+  const brandId = normalizeBrand(brand || '');
+  const brandCars = allCars.filter(car => normalizeBrand(car.brand) === brandId);
   
   const filteredCars = brandCars.filter(car =>
     car.name.toLowerCase().includes(searchTerm.toLowerCase()) ||


### PR DESCRIPTION
## Summary
- Normalize brand identifiers in brand pages so Mercedes models like G-Class, EQS, AMG GT, and Maybach appear
- Align category brand counting with normalized IDs to include Mercedes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and other pre-existing issues)*

------
https://chatgpt.com/codex/tasks/task_b_68ac13b7131483328db3339d5769296c