### PR TITLE
Fix lint warnings in search and auth components

### DIFF
--- a/src/components/AdvancedSearch.tsx
+++ b/src/components/AdvancedSearch.tsx
@@ -8,7 +8,7 @@ import { Slider } from "@/components/ui/slider";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Search, SlidersHorizontal, X } from "lucide-react";
-import { massiveCarsDatabase, expandedBrands } from "@/data/massiveCarsDatabase";
+import { massiveCarsDatabase, expandedBrands, type ExtendedCarDetails } from "@/data/massiveCarsDatabase";
 import { useNavigate } from "react-router-dom";
 
 interface AdvancedSearchProps {
@@ -31,7 +31,7 @@ const AdvancedSearch = ({ isOpen, onClose }: AdvancedSearchProps) => {
     minRating: 0
   });
 
-  const [searchResults, setSearchResults] = useState<any[]>([]);
+  const [searchResults, setSearchResults] = useState<ExtendedCarDetails[]>([]);
 
   const categories = [
     "כל הקטגוריות",
@@ -104,7 +104,7 @@ const AdvancedSearch = ({ isOpen, onClose }: AdvancedSearchProps) => {
     setSearchResults([]);
   };
 
-  const handleCarClick = (car: any) => {
+  const handleCarClick = (car: ExtendedCarDetails) => {
     navigate(`/car/${car.brand.toLowerCase().replace(/[^a-z]/g, '')}/${car.id}`);
     onClose();
   };

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -19,6 +19,7 @@ const AuthModal = ({ isOpen, onClose, defaultTab = "login" }: AuthModalProps) =>
   const [showPassword, setShowPassword] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const { toast } = useToast();
+  const { login, register } = useAuth();
 
   // Login state
   const [loginData, setLoginData] = useState({
@@ -40,7 +41,6 @@ const AuthModal = ({ isOpen, onClose, defaultTab = "login" }: AuthModalProps) =>
     setIsLoading(true);
 
     try {
-      const { login } = useAuth();
       const success = await login(loginData.email, loginData.password);
       
       if (success) {
@@ -81,7 +81,6 @@ const AuthModal = ({ isOpen, onClose, defaultTab = "login" }: AuthModalProps) =>
     setIsLoading(true);
 
     try {
-      const { register } = useAuth();
       const success = await register(
         registerData.fullName,
         registerData.email,


### PR DESCRIPTION
## Summary
- use explicit `ExtendedCarDetails` type in AdvancedSearch
- call `useAuth` hook at the top level in AuthModal

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68aeb5dc60908332bcbfe7b636977959