### PR TITLE
Fix lint warnings, handle brand logos, use local car images, and restore homepage search

### DIFF
--- a/src/components/AdvancedSearch.tsx
+++ b/src/components/AdvancedSearch.tsx
@@ -8,7 +8,7 @@ import { Slider } from "@/components/ui/slider";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Search, SlidersHorizontal, X } from "lucide-react";
-import { massiveCarsDatabase, expandedBrands } from "@/data/massiveCarsDatabase";
+import { massiveCarsDatabase, expandedBrands, type ExtendedCarDetails } from "@/data/massiveCarsDatabase";
 import { useNavigate } from "react-router-dom";
 
 interface AdvancedSearchProps {
@@ -31,7 +31,7 @@ const AdvancedSearch = ({ isOpen, onClose }: AdvancedSearchProps) => {
     minRating: 0
   });
 
-  const [searchResults, setSearchResults] = useState<any[]>([]);
+  const [searchResults, setSearchResults] = useState<ExtendedCarDetails[]>([]);
 
   const categories = [
     "כל הקטגוריות",
@@ -104,7 +104,7 @@ const AdvancedSearch = ({ isOpen, onClose }: AdvancedSearchProps) => {
     setSearchResults([]);
   };
 
-  const handleCarClick = (car: any) => {
+  const handleCarClick = (car: ExtendedCarDetails) => {
     navigate(`/car/${car.brand.toLowerCase().replace(/[^a-z]/g, '')}/${car.id}`);
     onClose();
   };

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -19,6 +19,7 @@ const AuthModal = ({ isOpen, onClose, defaultTab = "login" }: AuthModalProps) =>
   const [showPassword, setShowPassword] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const { toast } = useToast();
+  const { login, register } = useAuth();
 
   // Login state
   const [loginData, setLoginData] = useState({
@@ -40,7 +41,6 @@ const AuthModal = ({ isOpen, onClose, defaultTab = "login" }: AuthModalProps) =>
     setIsLoading(true);
 
     try {
-      const { login } = useAuth();
       const success = await login(loginData.email, loginData.password);
       
       if (success) {
@@ -81,7 +81,6 @@ const AuthModal = ({ isOpen, onClose, defaultTab = "login" }: AuthModalProps) =>
     setIsLoading(true);
 
     try {
-      const { register } = useAuth();
       const success = await register(
         registerData.fullName,
         registerData.email,

--- a/src/components/Categories.tsx
+++ b/src/components/Categories.tsx
@@ -164,11 +164,17 @@ const Categories = () => {
               >
                 <CardHeader className="text-center pb-2">
                   {brand.logo && (
-                    <img 
-                      src={brand.logo} 
-                      alt={`${brand.name} logo`}
-                      className="w-16 h-16 mx-auto mb-4 object-contain group-hover:scale-110 transition-transform duration-300"
-                    />
+                    typeof brand.logo === "string" && (brand.logo.includes(".") || brand.logo.startsWith("/")) ? (
+                      <img
+                        src={brand.logo}
+                        alt={`${brand.name} logo`}
+                        className="w-16 h-16 mx-auto mb-4 object-contain group-hover:scale-110 transition-transform duration-300"
+                      />
+                    ) : (
+                      <div className="text-5xl mb-4 group-hover:scale-110 transition-transform duration-300">
+                        {brand.logo}
+                      </div>
+                    )
                   )}
                   <CardTitle className="text-xl group-hover:text-racing-red transition-colors">
                     {brand.name}

--- a/src/components/SmartSearch.tsx
+++ b/src/components/SmartSearch.tsx
@@ -34,6 +34,7 @@ const SmartSearch = ({
   const [recentSearches, setRecentSearches] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
   const navigate = useNavigate();
 
   // Load recent searches from localStorage
@@ -103,14 +104,24 @@ const SmartSearch = ({
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setSearchTerm(value);
-    
-    // Debounce search
-    setTimeout(() => {
-      if (value === searchTerm) {
-        performSearch(value);
-      }
-    }, 300);
   };
+
+  // Debounced search effect
+  useEffect(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+
+    debounceRef.current = setTimeout(() => {
+      performSearch(searchTerm);
+    }, 300);
+
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    };
+  }, [searchTerm]);
 
   // Handle search submission
   const handleSearch = (term: string = searchTerm) => {

--- a/src/data/massiveCarsDatabase.ts
+++ b/src/data/massiveCarsDatabase.ts
@@ -290,62 +290,6 @@ export const massiveCarsDatabase: ExtendedCarDetails[] = [
   createCar("mercedes-gle", "GLE", "Mercedes-Benz", "SUV יוקרה", "₪245,000", 362, 2024, mercedesEQC),
   createCar("mercedes-gls", "GLS", "Mercedes-Benz", "SUV יוקרה גדול", "₪340,000", 362, 2024, mercedesEQC),
   createCar("mercedes-glc", "GLC", "Mercedes-Benz", "SUV יוקרה קומפקטי", "₪200,000", 255, 2024, mercedesEQC),
-  createCar(
-    "mercedes-g-class",
-    "G-Class",
-    "Mercedes-Benz",
-    "SUV שטח יוקרה",
-    "₪1,700,000",
-    416,
-    2024,
-    "https://www.netcarshow.com/Mercedes-Benz-G_Class-2024-800-01.jpg"
-  ),
-  createCar(
-    "mercedes-amg-gt",
-    "AMG GT",
-    "Mercedes-Benz",
-    "סופרקאר",
-    "₪1,300,000",
-    469,
-    2024,
-    "https://www.netcarshow.com/Mercedes-AMG-GT-2024-800-01.jpg"
-  ),
-  createCar("mercedes-amg-c63", "AMG C63 S", "Mercedes-Benz", "סדאן ספורט", "₪335,000", 503, 2024, mercedesC63s),
-  createCar("mercedes-amg-e63", "AMG E63 S", "Mercedes-Benz", "סדאן ספורט", "₪480,000", 603, 2024, mercedesAmgNew),
-  createCar(
-    "mercedes-amg-s63",
-    "AMG S63",
-    "Mercedes-Benz",
-    "סדאן יוקרה ספורט",
-    "₪1,600,000",
-    630,
-    2024,
-    "https://www.netcarshow.com/Mercedes-AMG-S_63_E_Performance-2024-800-01.jpg"
-  ),
-  createCar(
-    "mercedes-eqs",
-    "EQS",
-    "Mercedes-Benz",
-    "סדאן חשמלי יוקרה",
-    "₪890,000",
-    516,
-    2024,
-    "https://www.netcarshow.com/Mercedes-Benz-EQS-2024-800-01.jpg",
-    true
-  ),
-  createCar("mercedes-eqc", "EQC", "Mercedes-Benz", "SUV חשמלי יוקרה", "₪305,000", 402, 2024, mercedesEQC, true),
-  createCar("mercedes-eqe", "EQE", "Mercedes-Benz", "סדאן חשמלי יוקרה", "₪335,000", 288, 2024, mercedesEQS, true),
-  createCar(
-    "mercedes-maybach-s-class",
-    "Maybach S-Class",
-    "Mercedes-Benz",
-    "סדאן יוקרה עילית",
-    "₪1,800,000",
-    496,
-    2024,
-    "https://www.netcarshow.com/Mercedes-Maybach-S_Class-2024-800-01.jpg"
-  ),
-
   createCar("mercedes-g-class", "G-Class", "Mercedes-Benz", "SUV שטח יוקרה", "₪1,700,000", 416, 2024, mercedesImage),
   createCar("mercedes-amg-gt", "AMG GT", "Mercedes-Benz", "סופרקאר", "₪1,300,000", 469, 2024, mercedesAmgNew),
   createCar("mercedes-amg-c63", "AMG C63 S", "Mercedes-Benz", "סדאן ספורט", "₪335,000", 503, 2024, mercedesC63s),


### PR DESCRIPTION
## Summary
- use explicit `ExtendedCarDetails` type in AdvancedSearch
- call `useAuth` hook at the top level in AuthModal
- render emoji brand logos as text when no image is provided
- replace external Mercedes car image URLs with local assets
- debounce SmartSearch input to restore home page search

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68aeb5dc60908332bcbfe7b636977959