### PR TITLE
Add 2025 car prices page with images

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import CarDetailsPage from "./pages/CarDetailsPage";
 import BrandPage from "./pages/BrandPage";
 import CategoryPage from "./pages/CategoryPage";
 import FavoritesPage from "./pages/FavoritesPage";
+import PricesPage from "./pages/PricesPage";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -37,6 +38,7 @@ const App = () => (
               <Route path="/news" element={<NewsPage />} />
               <Route path="/community" element={<CommunityPage />} />
               <Route path="/favorites" element={<FavoritesPage />} />
+              <Route path="/prices" element={<PricesPage />} />
               {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
               <Route path="*" element={<NotFound />} />
             </Routes>

--- a/src/data/carPrices2025.ts
+++ b/src/data/carPrices2025.ts
@@ -1,0 +1,31 @@
+import carPricesData from "../../cursor_car_prices_il_2025/data/car_prices_il_2025.json";
+import toyotaCorolla from "@/assets/toyota-corolla.jpg";
+import hondaCivic from "@/assets/honda-civic-blue.jpg";
+import fordFiesta from "@/assets/ford-fiesta.jpg";
+
+export interface CarPrice {
+  make: string;
+  model: string;
+  year: number;
+  trim: string;
+  body_type: string;
+  fuel_type: string;
+  transmission: string;
+  doors: number;
+  seats: number;
+  price_ils: number;
+  currency: string;
+  price_source: string;
+  last_updated: string;
+  notes: string;
+}
+
+export const carPrices2025 = carPricesData as CarPrice[];
+
+const imageMap: Record<string, string> = {
+  "Toyota Corolla": toyotaCorolla,
+  "Honda Civic": hondaCivic,
+  "Ford Fiesta": fordFiesta,
+};
+
+export const getCarImage = (make: string, model: string) => imageMap[`${make} ${model}`];

--- a/src/pages/PricesPage.tsx
+++ b/src/pages/PricesPage.tsx
@@ -1,0 +1,38 @@
+import { carPrices2025, getCarImage } from "@/data/carPrices2025";
+
+const PricesPage = () => {
+  const displayed = carPrices2025.slice(0, 20);
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">מחירי רכב 2025</h1>
+      <table className="min-w-full text-left border-collapse">
+        <thead>
+          <tr>
+            <th className="p-2 border-b">תמונה</th>
+            <th className="p-2 border-b">דגם</th>
+            <th className="p-2 border-b">מחיר (₪)</th>
+          </tr>
+        </thead>
+        <tbody>
+          {displayed.map((car, idx) => (
+            <tr key={idx}>
+              <td className="p-2 border-b">
+                {getCarImage(car.make, car.model) && (
+                  <img
+                    src={getCarImage(car.make, car.model)}
+                    alt={`${car.make} ${car.model}`}
+                    className="h-16 w-auto object-cover"
+                  />
+                )}
+              </td>
+              <td className="p-2 border-b">{`${car.make} ${car.model}`}</td>
+              <td className="p-2 border-b">{car.price_ils.toLocaleString("he-IL")}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default PricesPage;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,6 +5,7 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "resolveJsonModule": true,
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary
- enable JSON imports in TS config
- add carPrices2025 dataset with sample images
- new PricesPage to display 2025 car prices and images
- route `/prices` to browse price table

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b053b547248332be8e56a39cf1cda3